### PR TITLE
Initialize aggregations map in AllMatches search, fixes #31

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@
 # Please keep the list sorted.
 
 Marty Schoch <marty.schoch@gmail.com>
+Akshay Shekher <akshay.shekher@gmail.com>

--- a/search.go
+++ b/search.go
@@ -184,7 +184,8 @@ type AllMatches struct {
 func NewAllMatches(q Query) *AllMatches {
 	return &AllMatches{
 		BaseSearch: BaseSearch{
-			query: q,
+			query:        q,
+			aggregations: make(search.Aggregations),
 		},
 	}
 }

--- a/search_test.go
+++ b/search_test.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/blugelabs/bluge/search/aggregations"
 	"github.com/blugelabs/bluge/search/highlight"
 
 	"github.com/blugelabs/bluge/analysis/char"
@@ -1260,4 +1261,13 @@ func TestSearchHighlightingWithRegexpReplacement(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestAllMatchesWithAggregationIssue31(t *testing.T) {
+	query := NewMatchQuery("bluge").SetField("name")
+	request := NewAllMatches(query)
+
+	// This line would panic because aggregations map was not initialized internally
+	// should not panic with the fix
+	request.AddAggregation("score", aggregations.MaxStartingAt(search.DocumentScore(), 0))
 }


### PR DESCRIPTION
Fixes the issue linked, started initializing aggregations in AllMatches search.

-----
I am not sure not about test case though, i didn't find a good way to assert that adding the aggregation doesn't panic. Open to suggestions!