### PR TITLE
Fix possible runtime panic on DecRef call

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,4 +8,5 @@
 # Please keep the list sorted.
 
 Marty Schoch <marty.schoch@gmail.com>
+Michael Schuett <michaeljs1990@gmail.com>
 Akshay Shekher <akshay.shekher@gmail.com>

--- a/index/directory.go
+++ b/index/directory.go
@@ -49,6 +49,7 @@ type Directory interface {
 	// Item data is accessible via the returned *segment.Data structure
 	// A io.Closer is returned, which must be called to release
 	// resources held by this open item.
+	// NOTE: care must be taken to handle a possible nil io.Closer
 	Load(kind string, id uint64) (*segment.Data, io.Closer, error)
 
 	// Persist a new item with data from the provided WriterTo

--- a/index/segment_plugin.go
+++ b/index/segment_plugin.go
@@ -109,7 +109,7 @@ func (c *closeOnLastRefCounter) DecRef() error {
 	c.m.Lock()
 	c.refs--
 	var err error
-	if c.refs == 0 {
+	if c.refs == 0 && c.closer != nil {
 		err = c.closer.Close()
 	}
 	c.m.Unlock()

--- a/index/writer.go
+++ b/index/writer.go
@@ -472,7 +472,9 @@ func (s *Writer) loadSnapshot(epoch uint64) (*Snapshot, error) {
 
 	_, err = snapshot.ReadFrom(dataReader)
 	if err != nil {
-		_ = closer.Close()
+		if closer != nil {
+			_ = closer.Close()
+		}
 		return nil, err
 	}
 
@@ -482,17 +484,24 @@ func (s *Writer) loadSnapshot(epoch uint64) (*Snapshot, error) {
 		var fileCRCBytes []byte
 		fileCRCBytes, err = data.Read(data.Len()-crcWidth, data.Len())
 		if err != nil {
+			if closer != nil {
+				_ = closer.Close()
+			}
 			return nil, fmt.Errorf("error reading snapshot CRC: %w", err)
 		}
 		if !bytes.Equal(computedCRCBytes, fileCRCBytes) {
+			if closer != nil {
+				_ = closer.Close()
+			}
 			return nil, fmt.Errorf("CRC mismatch loading snapshot %d: computed: %x file: %x",
 				epoch, computedCRCBytes, fileCRCBytes)
 		}
 	}
-
-	err = closer.Close()
-	if err != nil {
-		return nil, err
+	if closer != nil {
+		err = closer.Close()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var running uint64

--- a/index/writer.go
+++ b/index/writer.go
@@ -520,7 +520,9 @@ func (s *Writer) loadSegment(id uint64, plugin *SegmentPlugin) (*segmentWrapper,
 	}
 	seg, err := plugin.Load(data)
 	if err != nil {
-		_ = closer.Close()
+		if closer != nil {
+			_ = closer.Close()
+		}
 		return nil, fmt.Errorf("error loading segment: %v", err)
 	}
 	return &segmentWrapper{

--- a/index/writer_offline.go
+++ b/index/writer_offline.go
@@ -121,7 +121,9 @@ func (s *WriterOffline) doMerge() error {
 				_ = closeOpenedSegs()
 				return fmt.Errorf("error loading segment from directory: %w", err)
 			}
-			closers = append(closers, closer)
+			if closer != nil {
+				closers = append(closers, closer)
+			}
 			seg, err := s.segPlugin.Load(data)
 			if err != nil {
 				_ = closeOpenedSegs()
@@ -177,7 +179,9 @@ func (s *WriterOffline) Close() error {
 	}
 	finalSeg, err := s.segPlugin.Load(data)
 	if err != nil {
-		_ = closer.Close()
+		if closer != nil {
+			_ = closer.Close()
+		}
 		return fmt.Errorf("error loading segment: %w", err)
 	}
 
@@ -204,5 +208,8 @@ func (s *WriterOffline) Close() error {
 		return fmt.Errorf("error recording snapshot: %w", err)
 	}
 
-	return closer.Close()
+	if closer != nil {
+		return closer.Close()
+	}
+	return nil
 }


### PR DESCRIPTION
The following error was hit when porting from bleve to bluge

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x17000ce]

goroutine 16 [running]:
github.com/blugelabs/bluge/index.(*closeOnLastRefCounter).DecRef(0xc0004b59e0, 0x10ca11a, 0x8000000000000000)
	/gocode/pkg/mod/github.com/blugelabs/bluge@v0.1.3/index/segment_plugin.go:113 +0xae
github.com/blugelabs/bluge/index.(*Snapshot).decRef(0xc0005a0780, 0x3, 0x8ffd3)
	/gocode/pkg/mod/github.com/blugelabs/bluge@v0.1.3/index/snapshot.go:77 +0xb3
github.com/blugelabs/bluge/index.(*Snapshot).Close(...)
	/gocode/pkg/mod/github.com/blugelabs/bluge@v0.1.3/index/snapshot.go:89
github.com/blugelabs/bluge/index.(*Writer).mergerLoop(0xc000069200, 0xc000606660, 0xc0000402a0)
	/gocode/pkg/mod/github.com/blugelabs/bluge@v0.1.3/index/merge.go:75 +0x4c5
created by github.com/blugelabs/bluge/index.OpenWriter
	/gocode/pkg/mod/github.com/blugelabs/bluge@v0.1.3/index/writer.go:131 +0x8cd
```

It seems like might be possible that https://github.com/blugelabs/bluge/blob/fe1f453e701a72cb3ee01b13b8a5e5f6e2b0f6cc/index/writer.go#L523 could throw a panic also as I don't see any other place segmentWrapper is initialized. It looks like a path exists where err is nil and the returned closer also is.

I am using the `bluge.InMemoryOnlyConfig`.