### PR TITLE
port bleve fix of html highlighter escaping HTML

### DIFF
--- a/search/highlight/format_html.go
+++ b/search/highlight/format_html.go
@@ -14,6 +14,8 @@
 
 package highlight
 
+import "html"
+
 const defaultHTMLHighlightBefore = "<mark>"
 const defaultHTMLHighlightAfter = "</mark>"
 
@@ -47,18 +49,18 @@ func (a *HTMLFragmentFormatter) Format(f *Fragment, orderedTermLocations TermLoc
 			break
 		}
 		// add the stuff before this location
-		rv += string(f.Orig[curr:termLocation.Start])
-		// add the color
+		rv += html.EscapeString(string(f.Orig[curr:termLocation.Start]))
+		// start the <mark> tag
 		rv += a.before
 		// add the term itself
-		rv += string(f.Orig[termLocation.Start:termLocation.End])
-		// reset the color
+		rv += html.EscapeString(string(f.Orig[termLocation.Start:termLocation.End]))
+		// end the <mark> tag
 		rv += a.after
 		// update current
 		curr = termLocation.End
 	}
 	// add any remaining text after the last token
-	rv += string(f.Orig[curr:f.End])
+	rv += html.EscapeString(string(f.Orig[curr:f.End]))
 
 	return rv
 }

--- a/search/highlight/format_html_test.go
+++ b/search/highlight/format_html_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/blugelabs/bluge/search"
 )
 
-func TestHTMLFragmentFormatter1(t *testing.T) {
+func TestHTMLFragmentFormatter(t *testing.T) {
 	tests := []struct {
 		name      string
 		fragment  *Fragment
@@ -68,6 +68,46 @@ func TestHTMLFragmentFormatter1(t *testing.T) {
 			beforeTag: "<em>",
 			afterTag:  "</em>",
 			output:    "the <em>quick</em> brown fox",
+		},
+		// test html escaping
+		{
+			fragment: &Fragment{
+				Orig:  []byte("<the> quick brown & fox"),
+				Start: 0,
+				End:   23,
+			},
+			tlm: search.TermLocationMap{
+				"quick": []*search.Location{
+					{
+						Pos:   2,
+						Start: 6,
+						End:   11,
+					},
+				},
+			},
+			output:    "&lt;the&gt; <em>quick</em> brown &amp; fox",
+			beforeTag: "<em>",
+			afterTag:  "</em>",
+		},
+		// test html escaping inside search term
+		{
+			fragment: &Fragment{
+				Orig:  []byte("<the> qu&ick brown & fox"),
+				Start: 0,
+				End:   24,
+			},
+			tlm: search.TermLocationMap{
+				"qu&ick": []*search.Location{
+					{
+						Pos:   2,
+						Start: 6,
+						End:   12,
+					},
+				},
+			},
+			output:    "&lt;the&gt; <em>qu&amp;ick</em> brown &amp; fox",
+			beforeTag: "<em>",
+			afterTag:  "</em>",
 		},
 	}
 

--- a/test/basic_test.go
+++ b/test/basic_test.go
@@ -60,7 +60,7 @@ func basicLoad(writer *bluge.Writer) error {
 		return err
 	}
 	err = writer.Insert(bluge.NewDocument("b").
-		AddField(bluge.NewTextField("name", "steve has a long name").
+		AddField(bluge.NewTextField("name", "steve has <a> long & complicated name").
 			SearchTermPositions().
 			StoreValue().
 			WithAnalyzer(enAnalyzer)).
@@ -141,7 +141,8 @@ func basicTests() []*RequestVerify {
 		{
 			Comment: "test match phrase search",
 			Request: bluge.NewTopNSearch(10,
-				bluge.NewMatchPhraseQuery("long name")),
+				bluge.NewMatchPhraseQuery("complicated name").
+					SetAnalyzer(enAnalyzer)),
 			Aggregations: standardAggs,
 			ExpectTotal:  1,
 			ExpectMatches: []*match{
@@ -377,7 +378,7 @@ func basicTests() []*RequestVerify {
 						{
 							Highlighter: highlight.NewHTMLHighlighter(),
 							Field:       "name",
-							Result:      "steve has a <mark>long</mark> name",
+							Result:      "steve has &lt;a&gt; <mark>long</mark> &amp; complicated name",
 						},
 					},
 				},
@@ -400,7 +401,7 @@ func basicTests() []*RequestVerify {
 						{
 							Highlighter: highlight.NewHTMLHighlighter(),
 							Field:       "name",
-							Result:      "steve has a <mark>long</mark> name",
+							Result:      "steve has &lt;a&gt; <mark>long</mark> &amp; complicated name",
 						},
 						{
 							Highlighter: highlight.NewHTMLHighlighter(),


### PR DESCRIPTION
this corresponds to b9b77599

and also includes an additional commit not yet merged to
bleve, that commit was mistakenly omitted and is
currently under review