### PR TITLE
Exposed sloppyness parameter in Query & Searcher

### DIFF
--- a/query.go
+++ b/query.go
@@ -110,8 +110,9 @@ func NewBooleanQuery() *BooleanQuery {
 
 // SetMinShould requires that at least minShould of the
 // should Queries must be satisfied.
-func (q *BooleanQuery) SetMinShould(minShould int) {
+func (q *BooleanQuery) SetMinShould(minShould int) *BooleanQuery {
 	q.minShould = minShould
+	return q
 }
 
 func (q *BooleanQuery) AddMust(m ...Query) *BooleanQuery {
@@ -119,14 +120,34 @@ func (q *BooleanQuery) AddMust(m ...Query) *BooleanQuery {
 	return q
 }
 
+// Musts returns the queries that the documents must match
+func (q *BooleanQuery) Musts() []Query {
+	return q.musts
+}
+
 func (q *BooleanQuery) AddShould(m ...Query) *BooleanQuery {
 	q.shoulds = append(q.shoulds, m...)
 	return q
 }
 
+// Shoulds returns queries that the documents may match
+func (q *BooleanQuery) Shoulds() []Query {
+	return q.shoulds
+}
+
 func (q *BooleanQuery) AddMustNot(m ...Query) *BooleanQuery {
 	q.mustNots = append(q.mustNots, m...)
 	return q
+}
+
+// MustNots returns queries that the documents must not match
+func (q *BooleanQuery) MustNots() []Query {
+	return q.mustNots
+}
+
+// MinShould returns the minimum number of should queries that need to match
+func (q *BooleanQuery) MinShould() int {
+	return q.minShould
 }
 
 func (q *BooleanQuery) SetBoost(b float64) *BooleanQuery {
@@ -284,6 +305,16 @@ func NewDateRangeInclusiveQuery(start, end time.Time, startInclusive, endInclusi
 	}
 }
 
+// Start returns the date range start and if the start is included in the query
+func (q *DateRangeQuery) Start() (time.Time, bool) {
+	return q.start, q.inclusiveStart
+}
+
+// End returns the date range end and if the end is included in the query
+func (q *DateRangeQuery) End() (time.Time, bool) {
+	return q.end, q.inclusiveEnd
+}
+
 func (q *DateRangeQuery) SetBoost(b float64) *DateRangeQuery {
 	boostVal := boost(b)
 	q.boost = &boostVal
@@ -387,6 +418,21 @@ func NewFuzzyQuery(term string) *FuzzyQuery {
 	}
 }
 
+// Term returns the term being queried
+func (q *FuzzyQuery) Term() string {
+	return q.term
+}
+
+// PrefixLen returns the prefix match value
+func (q *FuzzyQuery) Prefix() int {
+	return q.prefix
+}
+
+// Fuzziness returns the fuzziness of the query
+func (q *FuzzyQuery) Fuzziness() int {
+	return q.fuzziness
+}
+
 func (q *FuzzyQuery) SetBoost(b float64) *FuzzyQuery {
 	boostVal := boost(b)
 	q.boost = &boostVal
@@ -441,6 +487,16 @@ func NewGeoBoundingBoxQuery(topLeftLon, topLeftLat, bottomRightLon, bottomRightL
 		topLeft:     []float64{topLeftLon, topLeftLat},
 		bottomRight: []float64{bottomRightLon, bottomRightLat},
 	}
+}
+
+// TopLeft returns the start corner of the bounding box
+func (q *GeoBoundingBoxQuery) TopLeft() []float64 {
+	return q.topLeft
+}
+
+// BottomRight returns the end cornder of the bounding box
+func (q *GeoBoundingBoxQuery) BottomRight() []float64 {
+	return q.bottomRight
 }
 
 func (q *GeoBoundingBoxQuery) SetBoost(b float64) *GeoBoundingBoxQuery {
@@ -523,6 +579,16 @@ func NewGeoDistanceQuery(lon, lat float64, distance string) *GeoDistanceQuery {
 	}
 }
 
+// Location returns the location being queried
+func (q *GeoDistanceQuery) Location() []float64 {
+	return q.location
+}
+
+// Distance returns the distance being queried
+func (q *GeoDistanceQuery) Distance() string {
+	return q.distance
+}
+
 func (q *GeoDistanceQuery) SetBoost(b float64) *GeoDistanceQuery {
 	boostVal := boost(b)
 	q.boost = &boostVal
@@ -573,6 +639,11 @@ type GeoBoundingPolygonQuery struct {
 func NewGeoBoundingPolygonQuery(points []geo.Point) *GeoBoundingPolygonQuery {
 	return &GeoBoundingPolygonQuery{
 		points: points}
+}
+
+// Points returns all the points being queried inside the bounding box
+func (q *GeoBoundingPolygonQuery) Points() []geo.Point {
+	return q.points
 }
 
 func (q *GeoBoundingPolygonQuery) SetBoost(b float64) *GeoBoundingPolygonQuery {
@@ -676,6 +747,11 @@ func NewMatchPhraseQuery(matchPhrase string) *MatchPhraseQuery {
 	return &MatchPhraseQuery{
 		matchPhrase: matchPhrase,
 	}
+}
+
+// Phrase returns the phrase being queried
+func (q *MatchPhraseQuery) Phrase() string {
+	return q.matchPhrase
 }
 
 func (q *MatchPhraseQuery) SetBoost(b float64) *MatchPhraseQuery {
@@ -789,6 +865,11 @@ func NewMatchQuery(match string) *MatchQuery {
 		match:    match,
 		operator: MatchQueryOperatorOr,
 	}
+}
+
+// Match returns the term being queried
+func (q *MatchQuery) Match() string {
+	return q.match
 }
 
 func (q *MatchQuery) SetBoost(b float64) *MatchQuery {
@@ -925,6 +1006,11 @@ func NewMultiPhraseQuery(terms [][]string) *MultiPhraseQuery {
 	}
 }
 
+// Terms returns the term phrases being queried
+func (q *MultiPhraseQuery) Terms() [][]string {
+	return q.terms
+}
+
 func (q *MultiPhraseQuery) SetBoost(b float64) *MultiPhraseQuery {
 	boostVal := boost(b)
 	q.boost = &boostVal
@@ -995,6 +1081,16 @@ func NewNumericRangeInclusiveQuery(min, max float64, minInclusive, maxInclusive 
 	}
 }
 
+// Min returns the numeric range lower bound and if the lowerbound is included
+func (q *NumericRangeQuery) Min() (float64, bool) {
+	return q.min, q.inclusiveMin
+}
+
+// Max returns the numeric range upperbound and if the upperbound is included
+func (q *NumericRangeQuery) Max() (float64, bool) {
+	return q.max, q.inclusiveMax
+}
+
 func (q *NumericRangeQuery) SetBoost(b float64) *NumericRangeQuery {
 	boostVal := boost(b)
 	q.boost = &boostVal
@@ -1049,6 +1145,11 @@ func NewPrefixQuery(prefix string) *PrefixQuery {
 	}
 }
 
+// Prefix return the prefix being queried
+func (q *PrefixQuery) Prefix() string {
+	return q.prefix
+}
+
 func (q *PrefixQuery) SetBoost(b float64) *PrefixQuery {
 	boostVal := boost(b)
 	q.boost = &boostVal
@@ -1091,6 +1192,11 @@ func NewRegexpQuery(regexp string) *RegexpQuery {
 	return &RegexpQuery{
 		regexp: regexp,
 	}
+}
+
+// Regexp returns the regular expression being queried
+func (q *RegexpQuery) Regexp() string {
+	return q.regexp
 }
 
 func (q *RegexpQuery) SetBoost(b float64) *RegexpQuery {
@@ -1165,6 +1271,11 @@ func (q *TermQuery) SetField(f string) *TermQuery {
 
 func (q *TermQuery) Field() string {
 	return q.field
+}
+
+// Term returns the exact term being queried
+func (q *TermQuery) Term() string {
+	return q.term
 }
 
 func (q *TermQuery) Searcher(i search.Reader, options search.SearcherOptions) (search.Searcher, error) {
@@ -1250,6 +1361,16 @@ func (q *TermRangeQuery) Validate() error {
 	return nil
 }
 
+// Min returns the query lower bound and if the lower bound is included in query
+func (q *TermRangeQuery) Min() (string, bool) {
+	return q.min, q.inclusiveMin
+}
+
+// Max returns the query upperbound and if the upper bound is included in the query
+func (q *TermRangeQuery) Max() (string, bool) {
+	return q.max, q.inclusiveMax
+}
+
 type WildcardQuery struct {
 	wildcard string
 	field    string
@@ -1266,6 +1387,11 @@ func NewWildcardQuery(wildcard string) *WildcardQuery {
 	return &WildcardQuery{
 		wildcard: wildcard,
 	}
+}
+
+// Wildcard returns the wildcard being queried
+func (q *WildcardQuery) Wildcard() string {
+	return q.wildcard
 }
 
 func (q *WildcardQuery) SetBoost(b float64) *WildcardQuery {

--- a/search/highlight/format_html.go
+++ b/search/highlight/format_html.go
@@ -14,6 +14,8 @@
 
 package highlight
 
+import "html"
+
 const defaultHTMLHighlightBefore = "<mark>"
 const defaultHTMLHighlightAfter = "</mark>"
 
@@ -47,18 +49,18 @@ func (a *HTMLFragmentFormatter) Format(f *Fragment, orderedTermLocations TermLoc
 			break
 		}
 		// add the stuff before this location
-		rv += string(f.Orig[curr:termLocation.Start])
-		// add the color
+		rv += html.EscapeString(string(f.Orig[curr:termLocation.Start]))
+		// start the <mark> tag
 		rv += a.before
 		// add the term itself
-		rv += string(f.Orig[termLocation.Start:termLocation.End])
-		// reset the color
+		rv += html.EscapeString(string(f.Orig[termLocation.Start:termLocation.End]))
+		// end the <mark> tag
 		rv += a.after
 		// update current
 		curr = termLocation.End
 	}
 	// add any remaining text after the last token
-	rv += string(f.Orig[curr:f.End])
+	rv += html.EscapeString(string(f.Orig[curr:f.End]))
 
 	return rv
 }

--- a/search/highlight/format_html_test.go
+++ b/search/highlight/format_html_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/blugelabs/bluge/search"
 )
 
-func TestHTMLFragmentFormatter1(t *testing.T) {
+func TestHTMLFragmentFormatter(t *testing.T) {
 	tests := []struct {
 		name      string
 		fragment  *Fragment
@@ -68,6 +68,46 @@ func TestHTMLFragmentFormatter1(t *testing.T) {
 			beforeTag: "<em>",
 			afterTag:  "</em>",
 			output:    "the <em>quick</em> brown fox",
+		},
+		// test html escaping
+		{
+			fragment: &Fragment{
+				Orig:  []byte("<the> quick brown & fox"),
+				Start: 0,
+				End:   23,
+			},
+			tlm: search.TermLocationMap{
+				"quick": []*search.Location{
+					{
+						Pos:   2,
+						Start: 6,
+						End:   11,
+					},
+				},
+			},
+			output:    "&lt;the&gt; <em>quick</em> brown &amp; fox",
+			beforeTag: "<em>",
+			afterTag:  "</em>",
+		},
+		// test html escaping inside search term
+		{
+			fragment: &Fragment{
+				Orig:  []byte("<the> qu&ick brown & fox"),
+				Start: 0,
+				End:   24,
+			},
+			tlm: search.TermLocationMap{
+				"qu&ick": []*search.Location{
+					{
+						Pos:   2,
+						Start: 6,
+						End:   12,
+					},
+				},
+			},
+			output:    "&lt;the&gt; <em>qu&amp;ick</em> brown &amp; fox",
+			beforeTag: "<em>",
+			afterTag:  "</em>",
 		},
 	}
 

--- a/search/searcher/search_phrase_test.go
+++ b/search/searcher/search_phrase_test.go
@@ -159,6 +159,71 @@ func TestMultiPhraseSearch(t *testing.T) {
 	}
 }
 
+func TestSloppyMultiPhraseSearch(t *testing.T) {
+	soptions := search.SearcherOptions{
+		SimilarityForField: func(field string) search.Similarity {
+			return similarity.NewBM25Similarity()
+		},
+		Explain:            true,
+		IncludeTermVectors: true,
+	}
+
+	tests := []struct {
+		phrase [][]string
+		docids []uint64
+		slop   int
+	}{
+		{
+			phrase: [][]string{{"angst"}, {"beer"}, {"database"}},
+			docids: []uint64{},
+			slop:   0,
+		},
+		{
+			phrase: [][]string{{"angst"}, {"beer"}, {"database"}},
+			docids: []uint64{baseTestIndexReaderDirect.docNumByID("2")},
+			slop:   1,
+		},
+		{
+			phrase: [][]string{{"apple", "angst"}, {"dank"}},
+			docids: []uint64{baseTestIndexReaderDirect.docNumByID("3")},
+			slop:   2,
+		},
+	}
+
+	for i, test := range tests {
+		searcher, err := NewSloppyMultiPhraseSearcher(baseTestIndexReader, test.phrase, "desc", test.slop, nil, soptions)
+		if err != nil {
+			t.Error(err)
+		}
+		ctx := &search.Context{
+			DocumentMatchPool: search.NewDocumentMatchPool(searcher.DocumentMatchPoolSize(), 0),
+		}
+		next, err := searcher.Next(ctx)
+		actualIds := []uint64{}
+		for err == nil && next != nil {
+			actualIds = append(actualIds, next.Number)
+			ctx.DocumentMatchPool.Put(next)
+			next, err = searcher.Next(ctx)
+		}
+		if err != nil {
+			t.Fatalf("error iterating searcher: %v for test %d", err, i)
+		}
+		if !reflect.DeepEqual(test.docids, actualIds) {
+			t.Fatalf("test case %d: expected ids: %v, got %v", i, test.docids, actualIds)
+		}
+
+		err = searcher.Close()
+		if err != nil {
+			t.Error(err)
+		}
+
+		err = baseTestIndexReader.Close()
+		if err != nil {
+			t.Error(err)
+		}
+	}
+}
+
 func TestFindPhrasePaths(t *testing.T) {
 	tests := []struct {
 		phrase [][]string

--- a/test/basic_test.go
+++ b/test/basic_test.go
@@ -60,7 +60,7 @@ func basicLoad(writer *bluge.Writer) error {
 		return err
 	}
 	err = writer.Insert(bluge.NewDocument("b").
-		AddField(bluge.NewTextField("name", "steve has a long name").
+		AddField(bluge.NewTextField("name", "steve has <a> long & complicated name").
 			SearchTermPositions().
 			StoreValue().
 			WithAnalyzer(enAnalyzer)).
@@ -141,7 +141,8 @@ func basicTests() []*RequestVerify {
 		{
 			Comment: "test match phrase search",
 			Request: bluge.NewTopNSearch(10,
-				bluge.NewMatchPhraseQuery("long name")),
+				bluge.NewMatchPhraseQuery("complicated name").
+					SetAnalyzer(enAnalyzer)),
 			Aggregations: standardAggs,
 			ExpectTotal:  1,
 			ExpectMatches: []*match{
@@ -377,7 +378,7 @@ func basicTests() []*RequestVerify {
 						{
 							Highlighter: highlight.NewHTMLHighlighter(),
 							Field:       "name",
-							Result:      "steve has a <mark>long</mark> name",
+							Result:      "steve has &lt;a&gt; <mark>long</mark> &amp; complicated name",
 						},
 					},
 				},
@@ -400,7 +401,7 @@ func basicTests() []*RequestVerify {
 						{
 							Highlighter: highlight.NewHTMLHighlighter(),
 							Field:       "name",
-							Result:      "steve has a <mark>long</mark> name",
+							Result:      "steve has &lt;a&gt; <mark>long</mark> &amp; complicated name",
 						},
 						{
 							Highlighter: highlight.NewHTMLHighlighter(),

--- a/test/integration.go
+++ b/test/integration.go
@@ -32,6 +32,18 @@ type match struct {
 	Locations        search.FieldTermLocationMap
 }
 
+func newIDMatches(ids ...string) []*match {
+	result := []*match{}
+
+	for _, id := range ids {
+		result = append(result, &match{
+			Fields: map[string][][]byte{
+				"_id": {[]byte(id)},
+			}})
+	}
+	return result
+}
+
 type ExpectHighlight struct {
 	Highlighter highlight.Highlighter
 	Field       string

--- a/test/phrase_test.go
+++ b/test/phrase_test.go
@@ -57,300 +57,180 @@ func phraseTests() []*RequestVerify {
 			Request: bluge.NewTopNSearch(10,
 				bluge.NewMatchPhraseQuery("Twenty").
 					SetAnalyzer(enAnalyzer)),
-			Aggregations: standardAggs,
-			ExpectTotal:  1,
-			ExpectMatches: []*match{
-				{
-					Fields: map[string][][]byte{
-						"_id": {[]byte("a")},
-					},
-				},
-			},
+			Aggregations:  standardAggs,
+			ExpectTotal:   1,
+			ExpectMatches: newIDMatches("a"),
 		},
 		{
 			Comment: "phrase 2",
 			Request: bluge.NewTopNSearch(10,
 				bluge.NewMatchPhraseQuery("Twenty Thousand").
 					SetAnalyzer(enAnalyzer)),
-			Aggregations: standardAggs,
-			ExpectTotal:  1,
-			ExpectMatches: []*match{
-				{
-					Fields: map[string][][]byte{
-						"_id": {[]byte("a")},
-					},
-				},
-			},
+			Aggregations:  standardAggs,
+			ExpectTotal:   1,
+			ExpectMatches: newIDMatches("a"),
 		},
 		{
 			Comment: "phrase 3",
 			Request: bluge.NewTopNSearch(10,
 				bluge.NewMatchPhraseQuery("Twenty Thousand Leagues").
 					SetAnalyzer(enAnalyzer)),
-			Aggregations: standardAggs,
-			ExpectTotal:  1,
-			ExpectMatches: []*match{
-				{
-					Fields: map[string][][]byte{
-						"_id": {[]byte("a")},
-					},
-				},
-			},
+			Aggregations:  standardAggs,
+			ExpectTotal:   1,
+			ExpectMatches: newIDMatches("a"),
 		},
 		{
 			Comment: "phrase 4",
 			Request: bluge.NewTopNSearch(10,
 				bluge.NewMatchPhraseQuery("Twenty Thousand Leagues Under").
 					SetAnalyzer(enAnalyzer)),
-			Aggregations: standardAggs,
-			ExpectTotal:  1,
-			ExpectMatches: []*match{
-				{
-					Fields: map[string][][]byte{
-						"_id": {[]byte("a")},
-					},
-				},
-			},
+			Aggregations:  standardAggs,
+			ExpectTotal:   1,
+			ExpectMatches: newIDMatches("a"),
 		},
 		{
 			Comment: "phrase 5",
 			Request: bluge.NewTopNSearch(10,
 				bluge.NewMatchPhraseQuery("Twenty Thousand Leagues Under the").
 					SetAnalyzer(enAnalyzer)),
-			Aggregations: standardAggs,
-			ExpectTotal:  1,
-			ExpectMatches: []*match{
-				{
-					Fields: map[string][][]byte{
-						"_id": {[]byte("a")},
-					},
-				},
-			},
+			Aggregations:  standardAggs,
+			ExpectTotal:   1,
+			ExpectMatches: newIDMatches("a"),
 		},
 		{
 			Comment: "phrase 6",
 			Request: bluge.NewTopNSearch(10,
 				bluge.NewMatchPhraseQuery("Twenty Thousand Leagues Under the Sea").
 					SetAnalyzer(enAnalyzer)),
-			Aggregations: standardAggs,
-			ExpectTotal:  1,
-			ExpectMatches: []*match{
-				{
-					Fields: map[string][][]byte{
-						"_id": {[]byte("a")},
-					},
-				},
-			},
+			Aggregations:  standardAggs,
+			ExpectTotal:   1,
+			ExpectMatches: newIDMatches("a"),
 		},
 		{
 			Comment: "phrase 7",
 			Request: bluge.NewTopNSearch(10,
 				bluge.NewMatchPhraseQuery("Thousand").
 					SetAnalyzer(enAnalyzer)),
-			Aggregations: standardAggs,
-			ExpectTotal:  1,
-			ExpectMatches: []*match{
-				{
-					Fields: map[string][][]byte{
-						"_id": {[]byte("a")},
-					},
-				},
-			},
+			Aggregations:  standardAggs,
+			ExpectTotal:   1,
+			ExpectMatches: newIDMatches("a"),
 		},
 		{
 			Comment: "phrase 8",
 			Request: bluge.NewTopNSearch(10,
 				bluge.NewMatchPhraseQuery("Thousand Leagues").
 					SetAnalyzer(enAnalyzer)),
-			Aggregations: standardAggs,
-			ExpectTotal:  1,
-			ExpectMatches: []*match{
-				{
-					Fields: map[string][][]byte{
-						"_id": {[]byte("a")},
-					},
-				},
-			},
+			Aggregations:  standardAggs,
+			ExpectTotal:   1,
+			ExpectMatches: newIDMatches("a"),
 		},
 		{
 			Comment: "phrase 9",
 			Request: bluge.NewTopNSearch(10,
 				bluge.NewMatchPhraseQuery("Thousand Leagues Under").
 					SetAnalyzer(enAnalyzer)),
-			Aggregations: standardAggs,
-			ExpectTotal:  1,
-			ExpectMatches: []*match{
-				{
-					Fields: map[string][][]byte{
-						"_id": {[]byte("a")},
-					},
-				},
-			},
+			Aggregations:  standardAggs,
+			ExpectTotal:   1,
+			ExpectMatches: newIDMatches("a"),
 		},
 		{
 			Comment: "phrase 10",
 			Request: bluge.NewTopNSearch(10,
 				bluge.NewMatchPhraseQuery("Thousand Leagues Under the").
 					SetAnalyzer(enAnalyzer)),
-			Aggregations: standardAggs,
-			ExpectTotal:  1,
-			ExpectMatches: []*match{
-				{
-					Fields: map[string][][]byte{
-						"_id": {[]byte("a")},
-					},
-				},
-			},
+			Aggregations:  standardAggs,
+			ExpectTotal:   1,
+			ExpectMatches: newIDMatches("a"),
 		},
 		{
 			Comment: "phrase 11",
 			Request: bluge.NewTopNSearch(10,
 				bluge.NewMatchPhraseQuery("Thousand Leagues Under the Sea").
 					SetAnalyzer(enAnalyzer)),
-			Aggregations: standardAggs,
-			ExpectTotal:  1,
-			ExpectMatches: []*match{
-				{
-					Fields: map[string][][]byte{
-						"_id": {[]byte("a")},
-					},
-				},
-			},
+			Aggregations:  standardAggs,
+			ExpectTotal:   1,
+			ExpectMatches: newIDMatches("a"),
 		},
 		{
 			Comment: "phrase 12",
 			Request: bluge.NewTopNSearch(10,
 				bluge.NewMatchPhraseQuery("Leagues").
 					SetAnalyzer(enAnalyzer)),
-			Aggregations: standardAggs,
-			ExpectTotal:  1,
-			ExpectMatches: []*match{
-				{
-					Fields: map[string][][]byte{
-						"_id": {[]byte("a")},
-					},
-				},
-			},
+			Aggregations:  standardAggs,
+			ExpectTotal:   1,
+			ExpectMatches: newIDMatches("a"),
 		},
 		{
 			Comment: "phrase 13",
 			Request: bluge.NewTopNSearch(10,
 				bluge.NewMatchPhraseQuery("Leagues Under").
 					SetAnalyzer(enAnalyzer)),
-			Aggregations: standardAggs,
-			ExpectTotal:  1,
-			ExpectMatches: []*match{
-				{
-					Fields: map[string][][]byte{
-						"_id": {[]byte("a")},
-					},
-				},
-			},
+			Aggregations:  standardAggs,
+			ExpectTotal:   1,
+			ExpectMatches: newIDMatches("a"),
 		},
 		{
 			Comment: "phrase 14",
 			Request: bluge.NewTopNSearch(10,
 				bluge.NewMatchPhraseQuery("Leagues Under the").
 					SetAnalyzer(enAnalyzer)),
-			Aggregations: standardAggs,
-			ExpectTotal:  1,
-			ExpectMatches: []*match{
-				{
-					Fields: map[string][][]byte{
-						"_id": {[]byte("a")},
-					},
-				},
-			},
+			Aggregations:  standardAggs,
+			ExpectTotal:   1,
+			ExpectMatches: newIDMatches("a"),
 		},
 		{
 			Comment: "phrase 15",
 			Request: bluge.NewTopNSearch(10,
 				bluge.NewMatchPhraseQuery("Leagues Under the Sea").
 					SetAnalyzer(enAnalyzer)),
-			Aggregations: standardAggs,
-			ExpectTotal:  1,
-			ExpectMatches: []*match{
-				{
-					Fields: map[string][][]byte{
-						"_id": {[]byte("a")},
-					},
-				},
-			},
+			Aggregations:  standardAggs,
+			ExpectTotal:   1,
+			ExpectMatches: newIDMatches("a"),
 		},
 		{
 			Comment: "phrase 16",
 			Request: bluge.NewTopNSearch(10,
 				bluge.NewMatchPhraseQuery("Under the Sea").
 					SetAnalyzer(enAnalyzer)),
-			Aggregations: standardAggs,
-			ExpectTotal:  1,
-			ExpectMatches: []*match{
-				{
-					Fields: map[string][][]byte{
-						"_id": {[]byte("a")},
-					},
-				},
-			},
+			Aggregations:  standardAggs,
+			ExpectTotal:   1,
+			ExpectMatches: newIDMatches("a"),
 		},
 		{
 			Comment: "phrase 17",
 			Request: bluge.NewTopNSearch(10,
 				bluge.NewMatchPhraseQuery("the Sea").
 					SetAnalyzer(enAnalyzer)),
-			Aggregations: standardAggs,
-			ExpectTotal:  1,
-			ExpectMatches: []*match{
-				{
-					Fields: map[string][][]byte{
-						"_id": {[]byte("a")},
-					},
-				},
-			},
+			Aggregations:  standardAggs,
+			ExpectTotal:   1,
+			ExpectMatches: newIDMatches("a"),
 		},
 		{
 			Comment: "phrase 18",
 			Request: bluge.NewTopNSearch(10,
 				bluge.NewMatchPhraseQuery("Sea").
 					SetAnalyzer(enAnalyzer)),
-			Aggregations: standardAggs,
-			ExpectTotal:  1,
-			ExpectMatches: []*match{
-				{
-					Fields: map[string][][]byte{
-						"_id": {[]byte("a")},
-					},
-				},
-			},
+			Aggregations:  standardAggs,
+			ExpectTotal:   1,
+			ExpectMatches: newIDMatches("a"),
 		},
 		{
 			Comment: "phrase 19",
 			Request: bluge.NewTopNSearch(10,
 				bluge.NewMatchPhraseQuery("bad call").
 					SetAnalyzer(enAnalyzer)),
-			Aggregations: standardAggs,
-			ExpectTotal:  1,
-			ExpectMatches: []*match{
-				{
-					Fields: map[string][][]byte{
-						"_id": {[]byte("b")},
-					},
-				},
-			},
+			Aggregations:  standardAggs,
+			ExpectTotal:   1,
+			ExpectMatches: newIDMatches("b"),
 		},
 		{
 			Comment: "phrase 20",
 			Request: bluge.NewTopNSearch(10,
 				bluge.NewMatchPhraseQuery("defenseless receiver").
 					SetAnalyzer(enAnalyzer)),
-			Aggregations: standardAggs,
-			ExpectTotal:  1,
-			ExpectMatches: []*match{
-				{
-					Fields: map[string][][]byte{
-						"_id": {[]byte("b")},
-					},
-				},
-			},
+			Aggregations:  standardAggs,
+			ExpectTotal:   1,
+			ExpectMatches: newIDMatches("b"),
 		},
 		{
 			Comment: "phrase 21",
@@ -365,15 +245,9 @@ func phraseTests() []*RequestVerify {
 			Comment: "phrase 22",
 			Request: bluge.NewTopNSearch(10,
 				bluge.NewMultiPhraseQuery([][]string{{"twenti", "thirti"}, {"thousand"}})),
-			Aggregations: standardAggs,
-			ExpectTotal:  1,
-			ExpectMatches: []*match{
-				{
-					Fields: map[string][][]byte{
-						"_id": {[]byte("a")},
-					},
-				},
-			},
+			Aggregations:  standardAggs,
+			ExpectTotal:   1,
+			ExpectMatches: newIDMatches("a"),
 		},
 		{
 			Comment: "phrase 23",
@@ -383,6 +257,36 @@ func phraseTests() []*RequestVerify {
 			Aggregations:  standardAggs,
 			ExpectTotal:   0,
 			ExpectMatches: []*match{},
+		},
+		{
+			Comment: "phrase 24",
+			Request: bluge.NewTopNSearch(10,
+				bluge.NewMatchPhraseQuery("Twenty Thousand").
+					SetAnalyzer(enAnalyzer).
+					SetSlop(1)),
+			Aggregations:  standardAggs,
+			ExpectTotal:   1,
+			ExpectMatches: newIDMatches("a"),
+		},
+		{
+			Comment: "phrase 25",
+			Request: bluge.NewTopNSearch(10,
+				bluge.NewMatchPhraseQuery("Twenty Leagues").
+					SetAnalyzer(enAnalyzer).
+					SetSlop(1)),
+			Aggregations:  standardAggs,
+			ExpectTotal:   1,
+			ExpectMatches: newIDMatches("a"),
+		},
+		{
+			Comment: "phrase 26",
+			Request: bluge.NewTopNSearch(10,
+				bluge.NewMatchPhraseQuery("Twenty under the sea").
+					SetAnalyzer(enAnalyzer).
+					SetSlop(2)),
+			Aggregations:  standardAggs,
+			ExpectTotal:   1,
+			ExpectMatches: newIDMatches("a"),
 		},
 	}
 }


### PR DESCRIPTION
# Changes

- Exposed slop parameter to (Muti/Match)PhraseQuery
- Added a factory method MultiPhraseSearcher to take in slop as a parameter
- Added tests for the above
- In integ tests, added a utility function to create match results, to reduce verbosity