### PR TITLE
Added accessors to query structs

### DIFF
--- a/query.go
+++ b/query.go
@@ -305,6 +305,16 @@ func NewDateRangeInclusiveQuery(start, end time.Time, startInclusive, endInclusi
 	}
 }
 
+// Start returns the date range start and if the start is included in the query
+func (q *DateRangeQuery) Start() (time.Time, bool) {
+	return q.start, q.inclusiveStart
+}
+
+// End returns the date range end and if the end is included in the query
+func (q *DateRangeQuery) End() (time.Time, bool) {
+	return q.end, q.inclusiveEnd
+}
+
 func (q *DateRangeQuery) SetBoost(b float64) *DateRangeQuery {
 	boostVal := boost(b)
 	q.boost = &boostVal
@@ -413,6 +423,16 @@ func (q *FuzzyQuery) Term() string {
 	return q.term
 }
 
+// PrefixLen returns the prefix match value
+func (q *FuzzyQuery) Prefix() int {
+	return q.prefix
+}
+
+// Fuzziness returns the fuzziness of the query
+func (q *FuzzyQuery) Fuzziness() int {
+	return q.fuzziness
+}
+
 func (q *FuzzyQuery) SetBoost(b float64) *FuzzyQuery {
 	boostVal := boost(b)
 	q.boost = &boostVal
@@ -467,6 +487,16 @@ func NewGeoBoundingBoxQuery(topLeftLon, topLeftLat, bottomRightLon, bottomRightL
 		topLeft:     []float64{topLeftLon, topLeftLat},
 		bottomRight: []float64{bottomRightLon, bottomRightLat},
 	}
+}
+
+// TopLeft returns the start corner of the bounding box
+func (q *GeoBoundingBoxQuery) TopLeft() []float64 {
+	return q.topLeft
+}
+
+// BottomRight returns the end cornder of the bounding box
+func (q *GeoBoundingBoxQuery) BottomRight() []float64 {
+	return q.bottomRight
 }
 
 func (q *GeoBoundingBoxQuery) SetBoost(b float64) *GeoBoundingBoxQuery {
@@ -547,6 +577,16 @@ func NewGeoDistanceQuery(lon, lat float64, distance string) *GeoDistanceQuery {
 		location: []float64{lon, lat},
 		distance: distance,
 	}
+}
+
+// Location returns the location being queried
+func (q *GeoDistanceQuery) Location() []float64 {
+	return q.location
+}
+
+// Distance returns the distance being queried
+func (q *GeoDistanceQuery) Distance() string {
+	return q.distance
 }
 
 func (q *GeoDistanceQuery) SetBoost(b float64) *GeoDistanceQuery {
@@ -1321,14 +1361,14 @@ func (q *TermRangeQuery) Validate() error {
 	return nil
 }
 
-// Min returns the query lower bound
-func (q *TermRangeQuery) Min() string {
-	return q.min
+// Min returns the query lower bound and if the lower bound is included in query
+func (q *TermRangeQuery) Min() (string, bool) {
+	return q.min, q.inclusiveMin
 }
 
-// Max returns the query upperbound
-func (q *TermRangeQuery) Max() string {
-	return q.max
+// Max returns the query upperbound and if the upper bound is included in the query
+func (q *TermRangeQuery) Max() (string, bool) {
+	return q.max, q.inclusiveMax
 }
 
 type WildcardQuery struct {

--- a/query.go
+++ b/query.go
@@ -110,8 +110,9 @@ func NewBooleanQuery() *BooleanQuery {
 
 // SetMinShould requires that at least minShould of the
 // should Queries must be satisfied.
-func (q *BooleanQuery) SetMinShould(minShould int) {
+func (q *BooleanQuery) SetMinShould(minShould int) *BooleanQuery {
 	q.minShould = minShould
+	return q
 }
 
 func (q *BooleanQuery) AddMust(m ...Query) *BooleanQuery {
@@ -119,14 +120,34 @@ func (q *BooleanQuery) AddMust(m ...Query) *BooleanQuery {
 	return q
 }
 
+// Musts returns the queries that the documents must match
+func (q *BooleanQuery) Musts() []Query {
+	return q.musts
+}
+
 func (q *BooleanQuery) AddShould(m ...Query) *BooleanQuery {
 	q.shoulds = append(q.shoulds, m...)
 	return q
 }
 
+// Shoulds returns queries that the documents may match
+func (q *BooleanQuery) Shoulds() []Query {
+	return q.shoulds
+}
+
 func (q *BooleanQuery) AddMustNot(m ...Query) *BooleanQuery {
 	q.mustNots = append(q.mustNots, m...)
 	return q
+}
+
+// MustNots returns queries that the documents must not match
+func (q *BooleanQuery) MustNots() []Query {
+	return q.mustNots
+}
+
+// MinShould returns the minimum number of should queries that need to match
+func (q *BooleanQuery) MinShould() int {
+	return q.minShould
 }
 
 func (q *BooleanQuery) SetBoost(b float64) *BooleanQuery {
@@ -387,6 +408,11 @@ func NewFuzzyQuery(term string) *FuzzyQuery {
 	}
 }
 
+// Term returns the term being queried
+func (q *FuzzyQuery) Term() string {
+	return q.term
+}
+
 func (q *FuzzyQuery) SetBoost(b float64) *FuzzyQuery {
 	boostVal := boost(b)
 	q.boost = &boostVal
@@ -575,6 +601,11 @@ func NewGeoBoundingPolygonQuery(points []geo.Point) *GeoBoundingPolygonQuery {
 		points: points}
 }
 
+// Points returns all the points being queried inside the bounding box
+func (q *GeoBoundingPolygonQuery) Points() []geo.Point {
+	return q.points
+}
+
 func (q *GeoBoundingPolygonQuery) SetBoost(b float64) *GeoBoundingPolygonQuery {
 	boostVal := boost(b)
 	q.boost = &boostVal
@@ -676,6 +707,11 @@ func NewMatchPhraseQuery(matchPhrase string) *MatchPhraseQuery {
 	return &MatchPhraseQuery{
 		matchPhrase: matchPhrase,
 	}
+}
+
+// Phrase returns the phrase being queried
+func (q *MatchPhraseQuery) Phrase() string {
+	return q.matchPhrase
 }
 
 func (q *MatchPhraseQuery) SetBoost(b float64) *MatchPhraseQuery {
@@ -789,6 +825,11 @@ func NewMatchQuery(match string) *MatchQuery {
 		match:    match,
 		operator: MatchQueryOperatorOr,
 	}
+}
+
+// Match returns the term being queried
+func (q *MatchQuery) Match() string {
+	return q.match
 }
 
 func (q *MatchQuery) SetBoost(b float64) *MatchQuery {
@@ -925,6 +966,11 @@ func NewMultiPhraseQuery(terms [][]string) *MultiPhraseQuery {
 	}
 }
 
+// Terms returns the term phrases being queried
+func (q *MultiPhraseQuery) Terms() [][]string {
+	return q.terms
+}
+
 func (q *MultiPhraseQuery) SetBoost(b float64) *MultiPhraseQuery {
 	boostVal := boost(b)
 	q.boost = &boostVal
@@ -995,6 +1041,16 @@ func NewNumericRangeInclusiveQuery(min, max float64, minInclusive, maxInclusive 
 	}
 }
 
+// Min returns tehe numeric range lower bound
+func (q *NumericRangeQuery) Min() float64 {
+	return q.min
+}
+
+// Max returns the numeric range upperbound
+func (q *NumericRangeQuery) Max() float64 {
+	return q.max
+}
+
 func (q *NumericRangeQuery) SetBoost(b float64) *NumericRangeQuery {
 	boostVal := boost(b)
 	q.boost = &boostVal
@@ -1049,6 +1105,11 @@ func NewPrefixQuery(prefix string) *PrefixQuery {
 	}
 }
 
+// Prefix return the prefix being queried
+func (q *PrefixQuery) Prefix() string {
+	return q.prefix
+}
+
 func (q *PrefixQuery) SetBoost(b float64) *PrefixQuery {
 	boostVal := boost(b)
 	q.boost = &boostVal
@@ -1091,6 +1152,11 @@ func NewRegexpQuery(regexp string) *RegexpQuery {
 	return &RegexpQuery{
 		regexp: regexp,
 	}
+}
+
+// Regexp returns the regular expression being queried
+func (q *RegexpQuery) Regexp() string {
+	return q.regexp
 }
 
 func (q *RegexpQuery) SetBoost(b float64) *RegexpQuery {
@@ -1165,6 +1231,11 @@ func (q *TermQuery) SetField(f string) *TermQuery {
 
 func (q *TermQuery) Field() string {
 	return q.field
+}
+
+// Term returns the exact term being queried
+func (q *TermQuery) Term() string {
+	return q.term
 }
 
 func (q *TermQuery) Searcher(i search.Reader, options search.SearcherOptions) (search.Searcher, error) {
@@ -1250,6 +1321,16 @@ func (q *TermRangeQuery) Validate() error {
 	return nil
 }
 
+// Min returns the query lower bound
+func (q *TermRangeQuery) Min() string {
+	return q.min
+}
+
+// Max returns the query upperbound
+func (q *TermRangeQuery) Max() string {
+	return q.max
+}
+
 type WildcardQuery struct {
 	wildcard string
 	field    string
@@ -1266,6 +1347,11 @@ func NewWildcardQuery(wildcard string) *WildcardQuery {
 	return &WildcardQuery{
 		wildcard: wildcard,
 	}
+}
+
+// Wildcard returns the wildcard being queried
+func (q *WildcardQuery) Wildcard() string {
+	return q.wildcard
 }
 
 func (q *WildcardQuery) SetBoost(b float64) *WildcardQuery {

--- a/query.go
+++ b/query.go
@@ -1081,14 +1081,14 @@ func NewNumericRangeInclusiveQuery(min, max float64, minInclusive, maxInclusive 
 	}
 }
 
-// Min returns tehe numeric range lower bound
-func (q *NumericRangeQuery) Min() float64 {
-	return q.min
+// Min returns the numeric range lower bound and if the lowerbound is included
+func (q *NumericRangeQuery) Min() (float64, bool) {
+	return q.min, q.inclusiveMin
 }
 
-// Max returns the numeric range upperbound
-func (q *NumericRangeQuery) Max() float64 {
-	return q.max
+// Max returns the numeric range upperbound and if the upperbound is included
+func (q *NumericRangeQuery) Max() (float64, bool) {
+	return q.max, q.inclusiveMax
 }
 
 func (q *NumericRangeQuery) SetBoost(b float64) *NumericRangeQuery {


### PR DESCRIPTION
## Background

When i use the [query_string](https://github.com/blugelabs/query_string/) package, i get a query tree but it's opaque and can't be modified. I want to use custom analyzers, boosts, parameters for fields queries.

I've implemented a `QueryVisitor` in my code, which let's me traverse the query tree and modify it as needed but the problem is that once a Query is generated, it's parameters are not visible.

## Solution

With this change, I can read the properties of the sub-queries and transform them according to my logic.

Note: This commit only updates one existing method `SetMinShould` to return `*BooleanQuery` to be consistent with other methods and convenience.

Note<sup>2</sup>: My visit interface looks like the following

```golang
type QueryVisitor interface {
	VisitBooleanQuery(q *bluge.BooleanQuery) bluge.Query
	VisitDateRangeQuery(q *bluge.DateRangeQuery) bluge.Query
	VisitFuzzyQuery(q *bluge.FuzzyQuery) bluge.Query
	VisitMatchAllQuery(q *bluge.MatchAllQuery) bluge.Query
	VisitMatchNoneQuery(q *bluge.MatchNoneQuery) bluge.Query
	VisitMatchPhraseQuery(q *bluge.MatchPhraseQuery) bluge.Query
	VisitMatchQuery(q *bluge.MatchQuery) bluge.Query
	VisitTermQuery(q *bluge.TermQuery) bluge.Query
	VisitTermRangeQuery(q *bluge.TermRangeQuery) bluge.Query
	VisitRegexpQuery(q *bluge.RegexpQuery) bluge.Query
	VisitWildcardQuery(q *bluge.WildcardQuery) bluge.Query
	VisitMultiPhraseQuery(q *bluge.MultiPhraseQuery) bluge.Query
}
```
