### PR TITLE
fix handling of snapshots with 0 segments

### DIFF
--- a/index/snapshot.go
+++ b/index/snapshot.go
@@ -575,7 +575,7 @@ func (i *Snapshot) ReadFrom(r io.Reader) (int64, error) {
 
 	// read bluge snapshot format version
 	peek, err := br.Peek(binary.MaxVarintLen64)
-	if err != nil {
+	if err != nil && err != io.EOF {
 		return bytesRead, fmt.Errorf("error peeking snapshot format version %d: %w", i.epoch, err)
 	}
 	snapshotFormatVersion, n := binary.Uvarint(peek)
@@ -598,7 +598,7 @@ func (i *Snapshot) readFromVersion1(br *bufio.Reader) (int64, error) {
 
 	// read number of segments
 	peek, err := br.Peek(binary.MaxVarintLen64)
-	if err != nil {
+	if err != nil && err != io.EOF {
 		return bytesRead, fmt.Errorf("error peeking snapshot number of segments %d: %w", i.epoch, err)
 	}
 	numSegments, n := binary.Uvarint(peek)

--- a/index/writer.go
+++ b/index/writer.go
@@ -508,7 +508,7 @@ func (s *Writer) loadSnapshot(epoch uint64) (*Snapshot, error) {
 	for _, segSnapshot := range snapshot.segment {
 		segPlugin, err := loadSegmentPlugin(s.config.supportedSegmentPlugins, segSnapshot.segmentType, segSnapshot.segmentVersion)
 		if err != nil {
-			return nil, fmt.Errorf("error loading required segmetn plugin: %v", err)
+			return nil, fmt.Errorf("error loading required segment plugin: %v", err)
 		}
 		segSnapshot.segment, err = s.loadSegment(segSnapshot.id, segPlugin)
 		if err != nil {

--- a/index_test.go
+++ b/index_test.go
@@ -1412,3 +1412,62 @@ func randStrn(n int) string {
 func randStr() string {
 	return randStrn(maxRandStrLen)
 }
+
+func TestBug54(t *testing.T) {
+
+	tmpIndexPath := createTmpIndexPath(t)
+	defer cleanupTmpIndexPath(t, tmpIndexPath)
+
+	// first index 2 documents
+	config := DefaultConfig(tmpIndexPath)
+	indexWriter, err := OpenWriter(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	doc := NewDocument("a1")
+	doc.AddField(NewTextField("TestKey1", "TestKey Data1"))
+	if err = indexWriter.Update(doc.ID(), doc); err != nil {
+		t.Fatal(err)
+	}
+
+	doc = NewDocument("a2")
+	doc.AddField(NewTextField("TestKey2", "TestKey Data2"))
+	if err = indexWriter.Update(doc.ID(), doc); err != nil {
+		t.Fatal(err)
+	}
+
+	err = indexWriter.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// now delete both documents
+	indexWriter, err = OpenWriter(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err = indexWriter.Delete(Identifier("a1")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err = indexWriter.Delete(Identifier("a2")); err != nil {
+		t.Fatal(err)
+	}
+
+	err = indexWriter.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// now open index again
+	indexWriter, err = OpenWriter(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = indexWriter.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/index_test.go
+++ b/index_test.go
@@ -1414,7 +1414,6 @@ func randStr() string {
 }
 
 func TestBug54(t *testing.T) {
-
 	tmpIndexPath := createTmpIndexPath(t)
 	defer cleanupTmpIndexPath(t, tmpIndexPath)
 


### PR DESCRIPTION
the snapshot loading code did not properly handle
very small snapshot files, in which some peek'd values
hit the end of the file.  the rest of the code in this
area seems sound, just had to consider the possibility
of EOF.

also a typo in a log message was fixed

fixes #54