### PR TITLE
alternate fix to #66

### DIFF
--- a/index/config.go
+++ b/index/config.go
@@ -191,7 +191,7 @@ func defaultConfig() Config {
 		// trio results in better overall performance.
 		PersisterNapUnderNumFiles: 1000,
 
-		MemoryPressurePauseThreshold: math.MaxInt64,
+		MemoryPressurePauseThreshold: math.MaxInt32,
 
 		// VirtualFields allow you to describe a set of fields
 		// The index will behave as if all documents in this index were


### PR DESCRIPTION
This config value just needs a large integer.  By switching to
math.MaxInt32 we allow it to build correctly on 32-bit systems
but keep the config type simpler.