### PR TITLE
Fix panics on 32-bit platforms due to misaligned atomics

### DIFF
--- a/index/writer.go
+++ b/index/writer.go
@@ -30,6 +30,8 @@ import (
 )
 
 type Writer struct {
+	stats Stats
+
 	config         Config
 	deletionPolicy DeletionPolicy
 	directory      Directory
@@ -49,8 +51,6 @@ type Writer struct {
 	// control/track goroutines
 	closeCh    chan struct{}
 	asyncTasks sync.WaitGroup
-
-	stats Stats
 
 	closeOnce sync.Once
 }

--- a/index/writer.go
+++ b/index/writer.go
@@ -32,6 +32,9 @@ import (
 type Writer struct {
 	stats Stats
 
+	// state
+	nextSegmentID uint64
+
 	config         Config
 	deletionPolicy DeletionPolicy
 	directory      Directory
@@ -44,9 +47,6 @@ type Writer struct {
 
 	rootPersisted      []chan error // closed when root is persisted
 	persistedCallbacks []func(error)
-
-	// state
-	nextSegmentID uint64
 
 	// control/track goroutines
 	closeCh    chan struct{}


### PR DESCRIPTION
```
panic: unaligned 64-bit atomic operation

goroutine 231682 [running]:
runtime/internal/atomic.panicUnaligned()
runtime/internal/atomic/unaligned.go:8 +0x24
runtime/internal/atomic.Xadd64(0x45fd1c4, 0x1, 0x0, 0x4db85c0, 0x520ea10)
runtime/internal/atomic/asm_arm.s:233 +0x14
http://github.com/blugelabs/bluge/index.(*Writer).persisterLoop(0x45fd000, 0x4db8700, 0x4db8680, 0x67e6cc0, 0x67e6d00, 0x0, 0x0)
mailto:github.com/blugelabs/bluge@v0.1.7/index/persister.go:44 +0x128