### PR TITLE
Initialize in-memory writer from disk backup

### DIFF
--- a/config.go
+++ b/config.go
@@ -89,6 +89,15 @@ func InMemoryOnlyConfig() Config {
 	indexConfig := index.InMemoryOnlyConfig()
 	return defaultConfig(indexConfig)
 }
+
+func InMemoryFromBackup(path string) Config {
+	indexConfig := index.InMemoryOnlyConfig()
+	indexConfig.SnapshotDirectoryFunc = func() index.Directory {
+		return index.NewFileSystemDirectory(path)
+	}
+	return defaultConfig(indexConfig)
+}
+
 func DefaultConfigWithDirectory(df func() index.Directory) Config {
 	indexConfig := index.DefaultConfigWithDirectory(df)
 	return defaultConfig(indexConfig)

--- a/index/config.go
+++ b/index/config.go
@@ -40,6 +40,8 @@ type Config struct {
 	DirectoryFunc      func() Directory
 	NormCalc           func(string, int) float32
 
+	SnapshotDirectoryFunc func() Directory
+
 	MergeBufferSize int
 
 	// Optimizations

--- a/index/merge.go
+++ b/index/merge.go
@@ -158,7 +158,7 @@ func (s *Writer) executeMergeTask(merges chan *segmentMerge, task *mergeplan.Mer
 			return fmt.Errorf("merging failed: %v", err)
 		}
 
-		seg, err = s.loadSegment(newSegmentID, s.segPlugin)
+		seg, err = s.loadSegment(newSegmentID, s.segPlugin, s.directory)
 		if err != nil {
 			atomic.AddUint64(&s.stats.TotFileMergePlanTasksErr, 1)
 			return err
@@ -313,7 +313,7 @@ func (s *Writer) mergeSegmentBases(merges chan *segmentMerge, snapshot *Snapshot
 		return nil, 0, err
 	}
 
-	seg, err := s.loadSegment(newSegmentID, s.segPlugin)
+	seg, err := s.loadSegment(newSegmentID, s.segPlugin, s.directory)
 	if err != nil {
 		atomic.AddUint64(&s.stats.TotMemMergeErr, 1)
 		return nil, 0, err

--- a/index/persister.go
+++ b/index/persister.go
@@ -352,7 +352,7 @@ func (s *Writer) prepareIntroducePersist(persists chan *persistIntroduction, new
 	}()
 	var err error
 	for _, segmentID := range newSegmentIds {
-		newSegments[segmentID], err = s.loadSegment(segmentID, s.segPlugin)
+		newSegments[segmentID], err = s.loadSegment(segmentID, s.segPlugin, s.directory)
 		if err != nil {
 			return fmt.Errorf("error opening new segment %d, %v", segmentID, err)
 		}


### PR DESCRIPTION
Hello! First of all, thanks for the awesome library and all the hard work on search in Go ecosystem. 

We are using in-memory Bluge index. We also have a separate event stream with changes in the system. On application start we do initial indexing from the database and consume event stream to keep the index actual (starting from event ID known before initial indexing).

One thing we want to improve is a time since application start till possibility to use index. So the idea is to do index backups periodically (using `Reader.Backup` API), and then use the backup on start to initialize initial state for in-memory only index (applying missing updates from the event stream). Similar to Redis RDB periodic snapshots (but we can still catch up to the actual state using our event log).

This way we can reduce startup time from ~20s to ~1s.

This pull request contains changes which allow starting in-memory index using on-disk backup. It seems to work and provided test is passing. But to be honest I am not sure I fully understand how Bluge works internally and whether this approach makes sense in terms of correctness. I spent some time reading code - but I am still in a position where I need help from someone who understands internals, so trying to validate an idea here.

Having said this all, a couple of questions:

1.  Does the implementation here seems reasonable in terms of correctness? I.e. we are loading initial state for in-memory index using disk-based directory obtained from `Reader.Backup` call, but then switching to a fully in-memory index implementation.
2. If the answer on first question is yes – will such pull request be interesting for Bluge? I can re-work it in a better way from the API perspective if required.

  