### PR TITLE
Reuse doc values

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -140,12 +140,17 @@ func (dm *DocumentMatch) Reset() *DocumentMatch {
 	sortValue := dm.SortValue
 	// remember the FieldTermLocations backing array
 	ftls := dm.FieldTermLocations
+	docValues := dm.docValues
 	// idiom to copy over from empty DocumentMatch (0 allocations)
 	*dm = DocumentMatch{}
 	// reuse the [][]byte already allocated (and reset len to 0)
 	dm.SortValue = sortValue[:0]
 	// reuse the FieldTermLocations already allocated (and reset len to 0)
 	dm.FieldTermLocations = ftls[:0]
+	for key, slice := range docValues {
+		docValues[key] = slice[:0]
+	}
+	dm.docValues = docValues
 	return dm
 }
 


### PR DESCRIPTION
Reduces allocations by 75% for a single sort field.

Before:
![profile002](https://user-images.githubusercontent.com/988750/200439911-9f16c554-6063-4cd7-8e78-80c6253d0314.svg)

After:
![profile001](https://user-images.githubusercontent.com/988750/200439840-c9b830d5-24b7-4bd2-82f2-f8e862b97087.svg)
