### PR TITLE
Support illumos and Solaris

### DIFF
--- a/index/directory_fs_nix.go
+++ b/index/directory_fs_nix.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
-// +build darwin dragonfly freebsd linux netbsd openbsd
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || illumos || solaris
+// +build darwin dragonfly freebsd linux netbsd openbsd illumos solaris
 
 package index
 

--- a/index/lock/lock_nix.go
+++ b/index/lock/lock_nix.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
-// +build darwin dragonfly freebsd linux netbsd openbsd
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || illumos || solaris
+// +build darwin dragonfly freebsd linux netbsd openbsd illumos solaris
 
 package lock
 


### PR DESCRIPTION
This fixes build failure in recent versions of Grafana, e.g.:

```
# github.com/blugelabs/bluge/index/lock
../.gopath/pkg/mod/github.com/blugelabs/bluge@v0.1.9/index/lock/lock.go:33:9: undefined: open
../.gopath/pkg/mod/github.com/blugelabs/bluge@v0.1.9/index/lock/lock.go:37:9: undefined: open
../.gopath/pkg/mod/github.com/blugelabs/bluge@v0.1.9/index/lock/lock.go:49:11: e.unlock undefined (type *DefaultLockedFile has no field or method unlock)
```

I've tested this patch against grafana 9.2.4 and it now builds correctly.